### PR TITLE
[#12] Add resource formats to JSON

### DIFF
--- a/ckanext/packagezip/logic_action.py
+++ b/ckanext/packagezip/logic_action.py
@@ -2,24 +2,11 @@ import ckan.plugins as p
 import ckan.logic as logic
 from ckanext.archiver.model import Archival
 from ckan.logic.auth import get_package_object
-from ckanext.packagezip.util import FilenameDeduplicator
+from ckanext.packagezip.util import FilenameDeduplicator, datapackage_format
 from ckanext.packagezip.model import PackageZip
 
 LICENSE_LOOKUP = {
     'uk-ogl': 'OGL-UK-3.0',
-}
-
-
-FORMATS = ['csv', 'html', 'xls', 'xml', 'pdf', 'json', 'rdf', 'zip', 'ods',
-           'txt', 'aspx', 'doc', 'xsd', 'asp', 'ppt', 'kml', 'exe', 'xlsx']
-
-# WMS? SPARQL? SHTML? CSV/Zip?
-
-FORMATS_LOOKUP = {
-    'application/pdf; charset=binary': 'pdf',
-    'application/vnd.ms-excel; charset=binary': 'xls',
-    'application/zip; charset=binary': 'zip',
-    'txt/plain': 'txt',
 }
 
 @p.toolkit.side_effect_free
@@ -65,14 +52,13 @@ def datapackage_show(context, data_dict):
             cache_filepath = ''
         filename = fd.deduplicate(filename)
         resource_json = {'url': res['url'],
-                            'path': u'data/{0}'.format(filename),
-                            'cache_filepath': cache_filepath,
-                            'description': res['description']}
+                         'path': u'data/{0}'.format(filename),
+                         'cache_filepath': cache_filepath,
+                         'description': res['description']}
 
-        if res['format'].lower() in FORMATS:
-            resource_json['format'] = res['format'].lower()
-        elif FORMATS_LOOKUP.get(res['format'].lower()):
-            resource_json['format'] = FORMATS_LOOKUP.get(res['format'].lower())
+        format = datapackage_format(res['format'])
+        if format:
+            resource_json['format'] = format
 
         datapackage['resources'].append(resource_json)
 

--- a/ckanext/packagezip/logic_action.py
+++ b/ckanext/packagezip/logic_action.py
@@ -9,6 +9,19 @@ LICENSE_LOOKUP = {
     'uk-ogl': 'OGL-UK-3.0',
 }
 
+
+FORMATS = ['csv', 'html', 'xls', 'xml', 'pdf', 'json', 'rdf', 'zip', 'ods',
+           'txt', 'aspx', 'doc', 'xsd', 'asp', 'ppt', 'kml', 'exe', 'xlsx']
+
+# WMS? SPARQL? SHTML? CSV/Zip?
+
+FORMATS_LOOKUP = {
+    'application/pdf; charset=binary': 'pdf',
+    'application/vnd.ms-excel; charset=binary': 'xls',
+    'application/zip; charset=binary': 'zip',
+    'txt/plain': 'txt',
+}
+
 @p.toolkit.side_effect_free
 def datapackage_show(context, data_dict):
     """
@@ -51,9 +64,16 @@ def datapackage_show(context, data_dict):
                 filename = res['id']
             cache_filepath = ''
         filename = fd.deduplicate(filename)
-        datapackage['resources'].append({'url': res['url'],
-                                         'path': u'data/{0}'.format(filename),
-                                         'cache_filepath': cache_filepath,
-                                         'description': res['description']})
+        resource_json = {'url': res['url'],
+                            'path': u'data/{0}'.format(filename),
+                            'cache_filepath': cache_filepath,
+                            'description': res['description']}
+
+        if res['format'].lower() in FORMATS:
+            resource_json['format'] = res['format'].lower()
+        elif FORMATS_LOOKUP.get(res['format'].lower()):
+            resource_json['format'] = FORMATS_LOOKUP.get(res['format'].lower())
+
+        datapackage['resources'].append(resource_json)
 
     return datapackage

--- a/ckanext/packagezip/util.py
+++ b/ckanext/packagezip/util.py
@@ -22,12 +22,25 @@ class FilenameDeduplicator(object):
         self.seen.append(filename)
         return filename
 
-ACCEPTABLE_EXTENSIONS = ['csv', 'html', 'xls', 'xml', 'pdf',
-                         'json', 'rdf', 'zip', 'ods', 'txt',
-                         'aspx', 'doc', 'xsd', 'asp', 'ppt',
-                         'kml', 'exe', 'xlsx']
-
-MIME_TO_FORMAT_MAPPING = {
+CKAN_FORMAT_TO_DATA_PACKAGE_FORMAT = {
+    'csv': 'csv',
+    'html': 'html',
+    'xls': 'xls',
+    'xml': 'xml',
+    'pdf': 'pdf',
+    'json': 'json',
+    'rdf': 'rdf',
+    'zip': 'zip',
+    'ods': 'ods',
+    'txt': 'txt',
+    'aspx': 'aspx',
+    'doc': 'doc',
+    'xsd': 'xsd',
+    'asp': 'asp',
+    'ppt': 'ppt',
+    'kml': 'kml',
+    'exe': 'exe',
+    'xlsx': 'xlsx',
     'application/pdf; charset=binary': 'pdf',
     'application/vnd.ms-excel; charset=binary': 'xls',
     'application/zip; charset=binary': 'zip',
@@ -41,11 +54,4 @@ def datapackage_format(resource_format):
 
     "Would be expected to be the the standard file extension for this type of resource"
     '''
-    # Most of the resource formats when lowercase are acceptable file extensions
-    if resource_format.lower() in ACCEPTABLE_EXTENSIONS:
-        return resource_format.lower()
-
-    # Others have the mimetype stored as the format so we map to the
-    # appropriate file extension
-    if MIME_TO_FORMAT_MAPPING.get(resource_format.lower()):
-        return MIME_TO_FORMAT_MAPPING.get(resource_format.lower())
+    return CKAN_FORMAT_TO_DATA_PACKAGE_FORMAT.get(resource_format.lower())

--- a/ckanext/packagezip/util.py
+++ b/ckanext/packagezip/util.py
@@ -21,3 +21,31 @@ class FilenameDeduplicator(object):
 
         self.seen.append(filename)
         return filename
+
+ACCEPTABLE_EXTENSIONS = ['csv', 'html', 'xls', 'xml', 'pdf',
+                         'json', 'rdf', 'zip', 'ods', 'txt',
+                         'aspx', 'doc', 'xsd', 'asp', 'ppt',
+                         'kml', 'exe', 'xlsx']
+
+MIME_TO_FORMAT_MAPPING = {
+    'application/pdf; charset=binary': 'pdf',
+    'application/vnd.ms-excel; charset=binary': 'xls',
+    'application/zip; charset=binary': 'zip',
+    'txt/plain': 'txt',
+}
+
+def datapackage_format(resource_format):
+    '''
+    Convert from the format stored in resource.format into the format required by
+    the datapackage spec:
+
+    "Would be expected to be the the standard file extension for this type of resource"
+    '''
+    # Most of the resource formats when lowercase are acceptable file extensions
+    if resource_format.lower() in ACCEPTABLE_EXTENSIONS:
+        return resource_format.lower()
+
+    # Others have the mimetype stored as the format so we map to the
+    # appropriate file extension
+    if MIME_TO_FORMAT_MAPPING.get(resource_format.lower()):
+        return MIME_TO_FORMAT_MAPPING.get(resource_format.lower())

--- a/tests/test_package_zip.py
+++ b/tests/test_package_zip.py
@@ -44,9 +44,12 @@ class TestPackageZip(BaseCase):
             {'url': 'https://www.gov.uk/robots.txt',
              'description': 'Gov.UK Robots.txt',
              'format': 'TXT'},
+            {'url': 'http://example.com/index.html',
+             'description': 'Example.com',
+             'format': 'HTML'},
             {'url': 'https://httpbin.org/status/404',
              'description': 'Missing Resource',
-             'format': 'TXT'},
+             'format': 'txt/plain'},
         ]
         self.pkg = self._test_package(resources)
 
@@ -156,12 +159,15 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus a velit lectu
         assert_equals(['License', 'OGL-UK-3.0'],
                       doc.xpath('//tr[@id=\'license\']/td/text()'))
         assert_equals(doc.xpath('//ul/li/a[@class=\'local\']/@href'), ['data/robots.txt',
-                                                                       'data/robots1.txt'])
+                                                                       'data/robots1.txt',
+                                                                       'data/index.html'])
         assert_equals(doc.xpath('//ul/li/a[@class=\'local\']/text()'), ['DGU Robots.txt',
-                                                                        'Gov.UK Robots.txt'])
+                                                                        'Gov.UK Robots.txt',
+                                                                        'Example.com'])
         assert_equals(doc.xpath('//ul/li/span[@class=\'missing\']/text()'), ['Missing Resource'])
         src_urls = ['http://data.gov.uk/robots.txt',
                     'https://www.gov.uk/robots.txt',
+                    'http://example.com/index.html',
                     'https://httpbin.org/status/404']
         assert_equals(doc.xpath('//ul/li/a[@class=\'source\']/@href'), src_urls)
         assert_equals(doc.xpath('//div[@id=\'created\']/text()')[0].strip(),
@@ -185,19 +191,27 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus a velit lectu
         assert_equals(datapackage['description'], self.pkg['notes'])
         assert_equals(datapackage['license'], 'OGL-UK-3.0')
 
-        assert_equals(len(datapackage['resources']), 3)
+        assert_equals(len(datapackage['resources']), 4)
 
         assert_equals(datapackage['resources'][0]['path'], 'data/robots.txt')
         assert_equals(datapackage['resources'][0]['url'], 'http://data.gov.uk/robots.txt')
+        assert_equals(datapackage['resources'][0]['format'], 'txt')
         assert_equals(datapackage['resources'][0]['included_in_zip'], True)
 
         assert_equals(datapackage['resources'][1]['path'], 'data/robots1.txt')
         assert_equals(datapackage['resources'][1]['url'], 'https://www.gov.uk/robots.txt')
+        assert_equals(datapackage['resources'][1]['format'], 'txt')
         assert_equals(datapackage['resources'][1]['included_in_zip'], True)
 
-        assert_equals(datapackage['resources'][2]['path'], 'data/404')
-        assert_equals(datapackage['resources'][2]['url'], 'https://httpbin.org/status/404')
-        assert_equals(datapackage['resources'][2]['included_in_zip'], False)
+        assert_equals(datapackage['resources'][2]['path'], 'data/index.html')
+        assert_equals(datapackage['resources'][2]['url'], 'http://example.com/index.html')
+        assert_equals(datapackage['resources'][2]['format'], 'html')
+        assert_equals(datapackage['resources'][2]['included_in_zip'], True)
+
+        assert_equals(datapackage['resources'][3]['path'], 'data/404')
+        assert_equals(datapackage['resources'][3]['url'], 'https://httpbin.org/status/404')
+        assert_equals(datapackage['resources'][3]['format'], 'txt')
+        assert_equals(datapackage['resources'][3]['included_in_zip'], False)
 
     def test_create_zip_task_again(self):
         package_id = self.pkg['id']


### PR DESCRIPTION
Fixes #12 

@davidread what do you think about WMS? SPARQL? SHTML? CSV/Zip? The format should be:

```
‘csv’, ‘xls’, ‘json’ etc. Would be expected to be the the standard file extension for this type of resource.
```

http://dataprotocols.org/data-packages/