### PR TITLE
Do not generate a zip file for unpublished datasets.

### DIFF
--- a/ckanext/packagezip/logic_action.py
+++ b/ckanext/packagezip/logic_action.py
@@ -14,6 +14,7 @@ LICENSE_LOOKUP = {
 @p.toolkit.side_effect_free
 def datapackage_show(context, data_dict):
     """
+    Generate the data required for a datapackage for the specified package.
     """
     model = context['model']
 
@@ -54,7 +55,6 @@ def datapackage_show(context, data_dict):
             except ValueError:
                 filename = res['id']
             cache_filepath = ''
-
 
         filename = fd.deduplicate(filename)
         resource_json = {'url': res['url'],

--- a/ckanext/packagezip/tasks.py
+++ b/ckanext/packagezip/tasks.py
@@ -3,6 +3,7 @@ from ckan import model
 from ckan.logic import get_action
 from ckanext.archiver.model import Archival
 from ckanext.packagezip.model import PackageZip
+import ckan.plugins.toolkit as t
 from pylons import config
 
 import os
@@ -45,6 +46,12 @@ def create_zip(ckan_ini_filepath, package_id, queue='bulk'):
 
     context = {'model': model, 'ignore_auth': True, 'session': model.Session}
     pkg = get_action('package_show')(context, {'id': package_id})
+
+    extras = dict([(d['key'], d['value'],) for d in pkg['extras']])
+    unpublished = t.asbool(extras.get('unpublished', False))
+    if unpublished:
+        log.info("Skipping unpublished dataset: %s", pkg['name'])
+        return
 
     directory = config.get('ckanext.packagezip.destination_dir')
     if not os.path.exists(directory):


### PR DESCRIPTION
If the package has an extra called unpublished, and it is set to True
then we will not create a .zip file for it (or at least we will not
try). They are not displayed anyway.

This should fix #20